### PR TITLE
👷 use organization's access token

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.QDQD_PAT }}
+          token: ${{ secrets.SMOOTH_QDQD_PAT_RIVATE_REPOSITORY }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.QDQD_PAT }}
+          token: ${{ secrets.SMOOTH_QDQD_PAT_RIVATE_REPOSITORY }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.QDQD_PAT }}
+          token: ${{ secrets.SMOOTH_QDQD_PAT_RIVATE_REPOSITORY }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.QDQD_PAT }}
+          token: ${{ secrets.SMOOTH_QDQD_PAT_RIVATE_REPOSITORY }}
 
       - name: Set up Python3
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.QDQD_PAT }}
+          token: ${{ secrets.SMOOTH_QDQD_PAT_RIVATE_REPOSITORY }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
As this repository use one of our private repository as a submodule, we need to use an access token to be able to clone it. This new access token is stored in the organization's secrets, improve the maintenance.