### PR TITLE
🧑‍💻 export the interface of the library

### DIFF
--- a/src/IWebAuthn256r1.sol
+++ b/src/IWebAuthn256r1.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.19 <0.9.0;
+
+interface IWebAuthn256r1 {
+    function verify(
+        bytes1 authenticatorDataFlagMask,
+        bytes calldata authenticatorData,
+        bytes calldata clientData,
+        bytes calldata clientChallenge,
+        uint256 clientChallengeOffset,
+        uint256 r,
+        uint256 s,
+        uint256 qx,
+        uint256 qy
+    )
+        external
+        returns (bool);
+}

--- a/test/WebAuthnWrapper.sol
+++ b/test/WebAuthnWrapper.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.19 <0.9.0;
 
-import { WebAuthn256r1 } from "../src/WebAuthn256r1.sol";
+import { WebAuthn256r1 } from "src/WebAuthn256r1.sol";
+import { IWebAuthn256r1 } from "src/IWebAuthn256r1.sol";
 
 /// @title WebAuthnWrapper
 /// @notice This minimalist contract wraps the WebAuthn library for test/script purposes
-contract WebAuthnWrapper {
+contract WebAuthnWrapper is IWebAuthn256r1 {
     function _generateMessage(
         bytes1 authenticatorDataFlagMask,
         bytes calldata authenticatorData,


### PR DESCRIPTION
Useful for builders who need to wrap the library