### PR TITLE
🔖 bump to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
-      "version": "0.3.1",
+      "version": "1.0.0",
       "devDependencies": {
         "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-computation": "^2.2.0",
         "lefthook": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
   "description": "WebAuthn library in Solidity",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "author": "0x90d2b2b7fb7599eebb6e7a32980857d8 https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8",
   "repository": "github:@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
   "bugs": "https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn/issues",


### PR DESCRIPTION
This version introduces a breaking change by changing the signature of the verify function. The offset of the challenge is now hardcoded in the library.