### PR TITLE
♻️ force the UV verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Description
 
-`webauthn` is a library designed for signature validation through the Web Authentication process. Currently, it supports only the ECDSA signature scheme utilizing the secp256r1 curve. This functionality is provided by the [secp256r1 library](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify). Support for additional algorithms is planned for future releases.
+`webauthn` is a library designed to validate passkeys. Currently, it supports only the ECDSA signature scheme utilizing the secp256r1 curve. This functionality is provided by the [secp256r1 library](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify). Support for additional algorithms is planned for future releases.
 
 ## Installation
 

--- a/src/IWebAuthn256r1.sol
+++ b/src/IWebAuthn256r1.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.19 <0.9.0;
 
 interface IWebAuthn256r1 {
     function verify(
-        bytes1 authenticatorDataFlagMask,
         bytes calldata authenticatorData,
         bytes calldata clientData,
         bytes calldata clientChallenge,

--- a/test/WebAuthn256r1.t.sol
+++ b/test/WebAuthn256r1.t.sol
@@ -6,247 +6,130 @@ import { WebAuthnWrapper } from "./WebAuthnWrapper.sol";
 import { WebAuthn256r1 } from "src/WebAuthn256r1.sol";
 
 struct Fixtures {
-    bytes1 authenticatorDataFlagMask;
     bytes authenticatorData;
     bytes clientData;
     bytes clientChallenge;
 }
 
-contract ContractTestVerify is Test {
-    bytes1 internal constant MASK_ACCEPT_UP = 0x01;
-    bytes1 internal constant MASK_ACCEPT_UV = 0x04;
-    bytes1 internal constant MASK_ACCEPT_BOTH = 0x05;
+contract WebAuthn256r1Test is Test {
     WebAuthnWrapper internal implem;
 
-    // TODO: Add more fixtures
-    Fixtures internal validFixtures = Fixtures({
-        authenticatorDataFlagMask: 0x01,
-        authenticatorData: hex"f8e4b678e1c62f7355266eaa4dc1148573440937063a46d848da1e25babbd20b010000004d",
-        clientData: hex"7b2274797065223a22776562617574686e2e676574222c226368616c6c656e67"
-            hex"65223a224e546f2d3161424547526e78786a6d6b61544865687972444e583369"
-            hex"7a6c7169316f776d4f643955474a30222c226f726967696e223a226874747073"
-            hex"3a2f2f66726573682e6c65646765722e636f6d222c2263726f73734f726967696e223a66616c73657d",
-        clientChallenge: hex"353a3ed5a0441919f1c639a46931de872ac3357de2ce5aa2d68c2639df54189d"
+    Fixtures internal fixtures = Fixtures({
+        clientChallenge: hex"9ecae66a110f82ee9403997aba9ca8749b735143799584e579d0e99e9e977085",
+        authenticatorData: hex"49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d00000000",
+        clientData: hex"7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a226e"
+            hex"73726d616845506775365541356c367570796f644a747a55554e356c59546c656444706e70"
+            hex"3658634955222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a333030"
+            hex"30222c2263726f73734f726967696e223a66616c73657d"
     });
 
     function setUp() external {
         implem = new WebAuthnWrapper();
     }
 
-    function test_GenerateMessage() external {
-        bytes32 message = implem._generateMessage(
-            validFixtures.authenticatorDataFlagMask,
-            validFixtures.authenticatorData,
-            validFixtures.clientData,
-            validFixtures.clientChallenge
-        );
+    function test_GenerateMessageCorrectly() external {
+        // it generate message correctly
+        bytes32 expectedMessage = 0x353bcfdce16baad69a5b9eadff9e36f7036155cd86a6cd1e423f2a786291290f;
 
-        assertEq(message, 0x4bfd0c06e1609b41d94e18b705de3163f6bf61fa44dcb8127c94bab7ba55fb9c);
+        bytes32 message =
+            implem._generateMessage(fixtures.authenticatorData, fixtures.clientData, fixtures.clientChallenge);
+
+        assertEq(message, expectedMessage);
     }
 
-    function test_AuthenticatorDataFlagMaskUPCorrect() external view {
-        bytes memory validAuthenticatorData = validFixtures.authenticatorData;
+    function test_RevertWhenAuthDataIsTooShort(bytes32 invalidAuthenticatorData) external {
+        // it revert when auth data is too short
 
-        // set the user presence flag in the valid authenticator data
-        validAuthenticatorData[32] = 0x01;
-
-        implem._generateMessage(
-            MASK_ACCEPT_UP, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-    }
-
-    function testFuzz_RevertWhen_AuthenticatorDataFlagMaskUPIncorrect(bytes1 incorrectFlag) external {
-        // make sure the fuzzed flag is incorrect for the UP mask
-        vm.assume(MASK_ACCEPT_UP & incorrectFlag == 0);
-        vm.expectRevert(WebAuthn256r1.InvalidAuthenticatorData.selector);
-
-        bytes memory validAuthenticatorData = validFixtures.authenticatorData;
-
-        // set the incorrect flag in the valid authenticator data
-        validAuthenticatorData[32] = incorrectFlag;
-
-        implem._generateMessage(
-            MASK_ACCEPT_UP, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-    }
-
-    function test_AuthenticatorDataFlagMaskUVCorrect() external view {
-        bytes memory validAuthenticatorData = validFixtures.authenticatorData;
-
-        // set the user validation flag in the valid authenticator data
-        validAuthenticatorData[32] = 0x04;
-
-        implem._generateMessage(
-            MASK_ACCEPT_UV, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-    }
-
-    function testFuzz_RevertWhen_AuthenticatorDataFlagMaskUVIncorrect(bytes1 incorrectFlag) external {
-        // make sure the fuzzed flag is incorrect for the UV mask
-        vm.assume(MASK_ACCEPT_UV & incorrectFlag == 0);
-        vm.expectRevert(WebAuthn256r1.InvalidAuthenticatorData.selector);
-
-        bytes memory validAuthenticatorData = validFixtures.authenticatorData;
-
-        // set the incorrect flag in the valid authenticator data
-        validAuthenticatorData[32] = incorrectFlag;
-
-        implem._generateMessage(
-            MASK_ACCEPT_UV, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-    }
-
-    function test_AuthenticatorDataFlagMaskBothCorrect() external view {
-        bytes memory validAuthenticatorData = validFixtures.authenticatorData;
-
-        // set the user presence flag in the valid authenticator data
-        validAuthenticatorData[32] = 0x01;
-
-        implem._generateMessage(
-            MASK_ACCEPT_BOTH, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-
-        // set the user validation flag in the valid authenticator data
-        validAuthenticatorData[32] = 0x04;
-
-        implem._generateMessage(
-            MASK_ACCEPT_BOTH, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-    }
-
-    function testFuzz_RevertWhen_AuthenticatorDataFlagMaskBothIncorrect(bytes1 incorrectFlag) external {
-        // make sure the fuzzed flag neither valid the UP mask nor the UV mask
-        vm.assume(MASK_ACCEPT_BOTH & incorrectFlag == 0);
-        vm.expectRevert(WebAuthn256r1.InvalidAuthenticatorData.selector);
-
-        bytes memory validAuthenticatorData = validFixtures.authenticatorData;
-
-        // set the incorrect flag in the valid authenticator data
-        validAuthenticatorData[32] = incorrectFlag;
-
-        implem._generateMessage(
-            MASK_ACCEPT_BOTH, validAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge
-        );
-    }
-
-    // @dev: this call validates the check of the authenticator data length works (>33)
-    function testFuzz_RevertWhen_AuthenticatorDataTooSmall(bytes32 tooSmallAuthenticatorData) external {
+        // the authenticator data is expected to be at least 33 bytes long. By passing a 32 bytes long
+        // authenticator data, we expect the function to revert.
         vm.expectRevert();
-
         implem._generateMessage(
-            MASK_ACCEPT_BOTH,
-            abi.encodePacked(tooSmallAuthenticatorData),
-            validFixtures.clientData,
-            validFixtures.clientChallenge
+            abi.encodePacked(invalidAuthenticatorData), fixtures.clientData, fixtures.clientChallenge
         );
     }
 
-    function test_AuthenticatorDataNeverTooBig() external view {
-        bytes memory bigAuthenticatorData = abi.encodePacked(
-            validFixtures.authenticatorData, validFixtures.authenticatorData, validFixtures.authenticatorData
-        );
+    function test_RevertWhenClientDataIncorrect(bytes calldata incorrectClientData) external {
+        // it revert when client data incorrect
 
-        implem._generateMessage(0x01, bigAuthenticatorData, validFixtures.clientData, validFixtures.clientChallenge);
-    }
-
-    function testFuzz_RevertWhen_ClientDataIncorrect(bytes calldata incorrectClientData) external {
-        // Exclude valid value from the fuzzing
-        // @dev: As you read this check, you're probably thinking that the probability of this happening
-        //       is absolutely zero, and you'd be right. But Foundry's fuzzing engine seems to be far from
-        //       perfect, which means that this case happens far more often than we imagine, and I don't know why.
-        // vm.assume(keccak256(incorrectClientData) != keccak256(validFixtures.clientData));
         vm.expectRevert();
-
-        try implem._generateMessage(
-            validFixtures.authenticatorDataFlagMask,
-            validFixtures.authenticatorData,
-            incorrectClientData,
-            validFixtures.clientChallenge
-        ) { } catch Error(string memory reason) {
-            // This block catches failing revert() and require()
-            // In our case, there is two possible valid revert reasons:
-            // 1.The value of the client has a length lower than the indexes used to read the challenge. In that case,
-            //   an out-of-bound is triggered by the EVM and the transaction revert.
-            // 2.The client data is simply not valid, meaning it doesn't pass the check in the contract
-
-            // Here we check the transaction reverted because of one of the two allowed scenarios
-            if (
-                bytes4(keccak256(bytes(reason))) != WebAuthn256r1.InvalidClientData.selector
-                    || keccak256(bytes(reason)) != keccak256("EvmError: Revert")
-            ) {
-                // If it's not the case, fail the test
+        try implem._generateMessage(fixtures.authenticatorData, incorrectClientData, fixtures.clientChallenge) { }
+        catch (bytes memory reason) {
+            // fail the test is the revert reason is not the expected one
+            if (keccak256(reason) == keccak256(abi.encodePacked(WebAuthn256r1.InvalidClientData.selector))) {
                 fail("Unknown reverted error");
             }
         }
     }
 
-    function testFuzz_RevertWhen_ClientChallengeIncorrect(bytes calldata incorrectClientChallenge) external {
-        // This scenario is tested by `testFuzz_RevertWhen_ClientChallengeIsNull`
-        vm.assume(incorrectClientChallenge.length > 0);
-        // Exclude valid value from the fuzzing
-        // @dev: As you read this check, you're probably thinking that the probability of this happening
-        //       is absolutely zero, and you'd be right. But Foundry's fuzzing engine seems to be far from
-        //       perfect, which means that this case happens far more often than we imagine, and I don't know why.
-        vm.assume(keccak256(incorrectClientChallenge) != keccak256(validFixtures.clientChallenge));
+    function modifyAuthenticatorDataFlag(
+        bytes calldata authenticatorData,
+        bytes1 newFlag
+    )
+        external
+        pure
+        returns (bytes memory data)
+    {
+        data = bytes.concat(authenticatorData[:32], newFlag, authenticatorData[33:]);
+    }
+
+    function test_RevertWhenOnlyUPIsSet() external {
+        // it revert when uv is not set
+
+        // modify the flag to only set the UP bit
+        bytes memory invalidAuthenticatorData =
+            WebAuthn256r1Test(address(this)).modifyAuthenticatorDataFlag(fixtures.authenticatorData, 0x01);
+
         vm.expectRevert();
+        implem._generateMessage(invalidAuthenticatorData, fixtures.clientData, fixtures.clientChallenge);
+    }
 
-        try implem._generateMessage(
-            validFixtures.authenticatorDataFlagMask,
-            validFixtures.authenticatorData,
-            validFixtures.clientData,
-            incorrectClientChallenge
-        ) { } catch Error(string memory reason) {
-            // This block catches failing revert() and require()
-            // In our case, there is two possible valid revert reasons:
-            // 1.The calculus of the end index overflows meaning we try to access a chunk of memory
-            //   by passing an end index lower than the start index. In this case, the EVM revert without reason
-            // 2.The calculus of the end index doesn't overflow but the end index is incorrect to the challenge check.
-            //   In this case, the EVM revert with the selector (first 4-bytes of the signature) of our custom Error.
+    function test_RevertWhenChallengeIncorrect(bytes calldata incorrectChallenge) external {
+        // it revert when challenge incorrect
 
-            // Here we check the transaction reverted because of one of the two allowed scenarios
-            if (
-                bytes4(keccak256(bytes(reason))) != WebAuthn256r1.InvalidClientData.selector
-                    || keccak256(bytes(reason)) != keccak256("EvmError: Revert")
-            ) {
-                // If it's not the case, fail the test
+        vm.assume(incorrectChallenge.length > 0);
+
+        vm.expectRevert();
+        try implem._generateMessage(fixtures.authenticatorData, fixtures.clientData, incorrectChallenge) { }
+        catch (bytes memory reason) {
+            // fail the test is the revert reason is not the expected one
+            if (keccak256(reason) == keccak256(abi.encodePacked(WebAuthn256r1.InvalidClientData.selector))) {
                 fail("Unknown reverted error");
             }
         }
     }
 
-    // @dev: By providing a null client challenge and an offset of 0, it was possible to pass the
-    //       challenge check without providing a valid challenge in the contract. This test ensure
-    //       that this scenario is not possible anymore
-    function testFuzz_RevertWhen_ClientChallengeIsNull() external {
-        vm.expectRevert(WebAuthn256r1.InvalidChallenge.selector);
+    function test_RevertWhenChallengeIsNull() external {
+        // it revert when challenge is null
 
-        implem._generateMessage(
-            validFixtures.authenticatorDataFlagMask, validFixtures.authenticatorData, validFixtures.clientData, ""
-        );
+        vm.expectRevert();
+        try implem._generateMessage(fixtures.authenticatorData, fixtures.clientData, hex"") { }
+        catch (bytes memory reason) {
+            // fail the test is the revert reason is not the expected one
+            if (keccak256(reason) == keccak256(abi.encodePacked(WebAuthn256r1.InvalidChallenge.selector))) {
+                fail("Unknown reverted error");
+            }
+        }
     }
 
-    function test_Verify() public {
+    function test_VerifyAValidWebauthnPayloadCorrectly() external {
+        // it verify a valid webauthn payload correctly
+
         assertTrue(
             implem.verify(
-                // authenticatorDataFlagMask
-                0x01,
                 // authenticatorData
-                hex"f8e4b678e1c62f7355266eaa4dc1148573440937063a46d848da1e25babbd20b010000004d",
+                fixtures.authenticatorData,
                 // clientData
-                hex"7b2274797065223a22776562617574686e2e676574222c226368616c6c656e67"
-                hex"65223a224e546f2d3161424547526e78786a6d6b61544865687972444e583369"
-                hex"7a6c7169316f776d4f643955474a30222c226f726967696e223a226874747073"
-                hex"3a2f2f66726573682e6c65646765722e636f6d222c2263726f73734f726967696e223a66616c73657d",
+                fixtures.clientData,
                 // clientChallenge
-                hex"353a3ed5a0441919f1c639a46931de872ac3357de2ce5aa2d68c2639df54189d",
+                fixtures.clientChallenge,
                 // r
-                45_847_212_378_479_006_099_766_816_358_861_726_414_873_720_355_505_495_069_909_394_794_949_093_093_607,
+                0x637f5e51e5e288310958cca253c12ef632869af03b2d398afb00c7a2ddcfcdd7,
                 // s
-                55_835_259_151_215_769_394_881_684_156_457_977_412_783_812_617_123_006_733_908_193_526_332_337_539_398,
+                0x0b29ee7b84c8faf6b452e4700d6bd55f93525f1e0be0800e0c1b37986d23717f,
                 // qx
-                114_874_632_398_302_156_264_159_990_279_427_641_021_947_882_640_101_801_130_664_833_947_273_521_181_002,
+                0xa33941ccf9b4eac590cda2457256babd0dca8379389b7e6612ab8fba34372a5b,
                 // qy
-                32_136_952_818_958_550_240_756_825_111_900_051_564_117_520_891_182_470_183_735_244_184_006_536_587_423
+                0xabe3b0cc14188c0ea28775b79120495f504df1e0f937bcbe88b2ee00f0d22c75
             )
         );
     }

--- a/test/WebAuthn256r1.tree
+++ b/test/WebAuthn256r1.tree
@@ -1,0 +1,8 @@
+WebAuthn256r1Test
+├── it generate message correctly
+├── it revert when auth data is too short
+├── it revert when client data incorrect
+├── it revert when only UP is set
+├── it revert when challenge incorrect
+├── it revert when challenge is null
+└── it verify a valid webauthn payload correctly

--- a/test/WebAuthnWrapper.sol
+++ b/test/WebAuthnWrapper.sol
@@ -8,7 +8,6 @@ import { IWebAuthn256r1 } from "src/IWebAuthn256r1.sol";
 /// @notice This minimalist contract wraps the WebAuthn library for test/script purposes
 contract WebAuthnWrapper is IWebAuthn256r1 {
     function _generateMessage(
-        bytes1 authenticatorDataFlagMask,
         bytes calldata authenticatorData,
         bytes calldata clientData,
         bytes calldata clientChallenge
@@ -17,11 +16,10 @@ contract WebAuthnWrapper is IWebAuthn256r1 {
         pure
         returns (bytes32)
     {
-        return WebAuthn256r1.generateMessage(authenticatorDataFlagMask, authenticatorData, clientData, clientChallenge);
+        return WebAuthn256r1.generateMessage(authenticatorData, clientData, clientChallenge);
     }
 
     function verify(
-        bytes1 authenticatorDataFlagMask,
         bytes calldata authenticatorData,
         bytes calldata clientData,
         bytes calldata clientChallenge,
@@ -33,8 +31,6 @@ contract WebAuthnWrapper is IWebAuthn256r1 {
         external
         returns (bool)
     {
-        return WebAuthn256r1.verify(
-            authenticatorDataFlagMask, authenticatorData, clientData, clientChallenge, r, s, qx, qy
-        );
+        return WebAuthn256r1.verify(authenticatorData, clientData, clientChallenge, r, s, qx, qy);
     }
 }


### PR DESCRIPTION
The library is developed to verify passkeys. The UV is enforced for passkeys, meaning it is not necessary to be passed as a parameter. Starting from this point, WebAuthn flow that didn't verify the user will fail the verification.