### PR TITLE
🔖 bump to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "devDependencies": {
         "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-computation": "^2.2.0",
         "lefthook": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
   "description": "WebAuthn library in Solidity",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "0x90d2b2b7fb7599eebb6e7a32980857d8 https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8",
   "repository": "github:@0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn",
   "bugs": "https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/webauthn/issues",


### PR DESCRIPTION
This version breaks the current API by removing the flag mask from the parameters.